### PR TITLE
updated nokogiri requirement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       typhoeus (~> 0.7)
     html-pipeline (2.6.0)
       activesupport (>= 2)
-      nokogiri (>= 1.4)
+      nokogiri (~> 1.10.4)
     i18n (0.8.6)
     jekyll (3.4.5)
       addressable (~> 2.4)


### PR DESCRIPTION
Updated nokogiri requirement to require  ~> 1.10.4 to address security vulnerability.